### PR TITLE
Disable document-ready handler after first run to avoid turbolinks problems

### DIFF
--- a/lib/pluggable_js/helpers.rb
+++ b/lib/pluggable_js/helpers.rb
@@ -10,9 +10,13 @@ module PluggableJs
           content << (javascript_tag "
             (function() {
               var function_name = '#{controller}##{action}';
+              var __#{controller}_#{action}_handler_active = true;
               if (typeof(this[function_name]) == 'function') {
                 $(function() {
-                  return window[function_name](#{@pluggable_js_data});
+                  if ( __#{controller}_#{action}_handler_active ) {
+                    __#{controller}_#{action}_handler_active = false;
+                    return window[function_name](#{@pluggable_js_data});
+                  }
                 });
               }
             }).call(this);"


### PR DESCRIPTION
I was having problems when using pluggable_js together with turbolinks and jquery.turbolinks: when loading the first page, the page specific js would run correctly. After that, each click on a turbolinks-link would cause it to run again, also on other pages.

This pull request makes sure that the code is run only one time. It's not the most elegant solution, but it works.
