### PR TITLE
fix Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.3
+  - 2.3.0
   - 2.2
   - 2.1
 
-script: bundle exec cucumber
+script: xvfb-run bundle exec cucumber


### PR DESCRIPTION
Continuation of #14 

There are a couple of errors:
- ruby 2.3 issue Travis-RVM: https://github.com/travis-ci/travis-ci/issues/5361
- use xvfb to run webkit tests

@peresleguine Even for a tiny gem, a remote CI is very useful for example: to test different Ruby platforms, catch up warnings, visualize specs output without cloning and installing the project...

Now, I think should be green :+1: 
